### PR TITLE
Fix typo error

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"release": "release-it"
 	},
 	"main": "./dist/index.js",
-	"module": "./dist/index.mjs",
+	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"files": [
 		"dist"
@@ -59,7 +59,7 @@
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"import": "./dist/index.mjs",
+			"import": "./dist/index.js",
 			"require": "./dist/index.cjs"
 		}
 	}


### PR DESCRIPTION
This was causing the package from running because no .mjs file was being generated.